### PR TITLE
Parent context

### DIFF
--- a/index.js
+++ b/index.js
@@ -58,6 +58,7 @@ function bind(thisArg, key, fn, options) {
         thisArg.options = merge({}, thisArg.options, val);
       }
     }
+    thisArg._parent = this;
     return fn.apply(thisArg, arguments);
   }
 }

--- a/index.js
+++ b/index.js
@@ -48,7 +48,7 @@ function bind(thisArg, key, fn, options) {
     }
 
     if (typeof options.bindFn === 'function') {
-      thisArg = options.bindFn(thisArg, key, options);
+      thisArg = options.bindFn(thisArg, key, this, options);
     }
 
     if (options.hasOwnProperty(key)) {
@@ -58,7 +58,6 @@ function bind(thisArg, key, fn, options) {
         thisArg.options = merge({}, thisArg.options, val);
       }
     }
-    thisArg._parent = this;
     return fn.apply(thisArg, arguments);
   }
 }

--- a/test.js
+++ b/test.js
@@ -72,6 +72,24 @@ describe('deepBind', function() {
     assert(helpers.abc.foo.async === true);
   });
 
+  it('should expose original context as _parent on bound context', function() {
+    var ctx = {
+      context: { c: 'd' }
+    };
+    var obj = {
+      context: { a: 'b' },
+      foo: function() {
+        return this._parent.context;
+      },
+      bar: function() {
+        return this.context;
+      }
+    };
+    var helpers = deepBind(obj, ctx);
+    assert.deepEqual(helpers.foo(), { a: 'b' })
+    assert.deepEqual(helpers.bar(), { c: 'd' })
+  });
+
   it('should expose property-specific options to a function', function() {
     var ctx = {
       app: {

--- a/test.js
+++ b/test.js
@@ -76,6 +76,7 @@ describe('deepBind', function() {
     var ctx = {
       context: { c: 'd' }
     };
+
     var obj = {
       context: { a: 'b' },
       foo: function() {
@@ -85,7 +86,14 @@ describe('deepBind', function() {
         return this.context;
       }
     };
-    var helpers = deepBind(obj, ctx);
+
+    var helpers = deepBind(obj, ctx, {
+      bindFn: function(thisArg, key, parent, options) {
+        thisArg._parent = parent;
+        return thisArg;
+      }
+    });
+
     assert.deepEqual(helpers.foo(), { a: 'b' })
     assert.deepEqual(helpers.bar(), { c: 'd' })
   });


### PR DESCRIPTION
This PR adds a `_parent` property to the `thisArg` so it's exposed in helpers as `this._parent`.
Since we're doing late binding by wrapping the original helper and calling `.apply`, we're able to get the original `this` context.

This is useful in handlebars helpers to get the current data context since handlebars also uses `.call` or `.apply` to set a specific context. This will allow using custom helpers inside `{{#each}}` and `{{#with}}` helpers and ensure we have the correct data context.

@jonschlinkert let me know what you think. I'm not set on using `_parent` if you think there's a better name. I also considered passing `this` to the `options.bindFn` to give the user of `deep-bind` control over how to use it. If we do that, then we could make the change in `templates` to add `_parent`.
