### PR TITLE
[issue #2] fix context leaking between seperate invokations

### DIFF
--- a/index.js
+++ b/index.js
@@ -43,22 +43,23 @@ function isObject(val) {
 
 function bind(thisArg, key, fn, options) {
   return function() {
-    if (!thisArg.hasOwnProperty('options')) {
-      thisArg.options = {};
+    var newThisArg = thisArg;  
+    if (!newThisArg.hasOwnProperty('options')) {
+      newThisArg.options = {};
     }
 
     if (typeof options.bindFn === 'function') {
-      thisArg = options.bindFn(thisArg, key, this, options);
+      newThisArg = options.bindFn(newThisArg, key, this, options);
     }
 
     if (options.hasOwnProperty(key)) {
       var val = options[key];
-      thisArg.options[key] = val;
+      newThisArg.options[key] = val;
       if (isObject(val)) {
-        thisArg.options = merge({}, thisArg.options, val);
+        newThisArg.options = merge({}, newThisArg.options, val);
       }
     }
-    return fn.apply(thisArg, arguments);
+    return fn.apply(newThisArg, arguments);
   }
 }
 


### PR DESCRIPTION
define a new variable inside the inner scope (body of the returned function) to prevent changes to the `thisArg` variable defined in the outer scope (bind method body) be leaking to the next invokations of the bound method